### PR TITLE
v-usb update from upstream

### DIFF
--- a/firmware/usbconfig.h
+++ b/firmware/usbconfig.h
@@ -49,7 +49,7 @@ the newest features and options.
  * Since F_CPU should be defined to your actual clock rate anyway, you should
  * not need to modify this setting.
  */
- #define USB_CFG_CHECK_CRC       1
+ #define USB_CFG_CHECK_CRC       0
 /* Define this to 1 if you want that the driver checks integrity of incoming
  * data packets (CRC checks). CRC checks cost quite a bit of code size and are
  * currently only available for 18 MHz crystal clock. You must choose
@@ -106,7 +106,7 @@ the newest features and options.
 /* Define this to 1 if the device has its own power supply. Set it to 0 if the
  * device is powered from the USB bus.
  */
-#define USB_CFG_MAX_BUS_POWER           100
+#define USB_CFG_MAX_BUS_POWER           50
 /* Set this variable to the maximum USB bus power consumption of your device.
  * The value is in milliamperes. [It will be divided by two since USB
  * communicates power requirements in units of 2 mA.]

--- a/firmware/usbconfig.h
+++ b/firmware/usbconfig.h
@@ -39,8 +39,7 @@ the newest features and options.
  * interrupt, the USB interrupt will also be triggered at Start-Of-Frame
  * markers every millisecond.]
  */
-//#define USB_CFG_CLOCK_KHZ 12000
-#define USB_CFG_CLOCK_KHZ 18000
+#define USB_CFG_CLOCK_KHZ 12000
 /* Clock rate of the AVR in kHz. Legal values are 12000, 12800, 15000, 16000,
  * 16500, 18000 and 20000. The 12.8 MHz and 16.5 MHz versions of the code
  * require no crystal, they tolerate +/- 1% deviation from the nominal

--- a/firmware/usbdrv/usbdrvasm15.inc
+++ b/firmware/usbdrv/usbdrvasm15.inc
@@ -410,7 +410,7 @@ skipAddrAssign:				;- [03/04]
     cbr     x2, USBMASK     		;1 [09] set both pins to input
     mov     x3, x1          		;1 [10]
     cbr     x3, USBMASK     		;1 [11] configure no pullup on both pins
-    ldi     x4, 3           		;1 [12]
+    ldi     x4, 2           		;1 [12]
 se0Delay:				;- [12] [15] 
     dec     x4              		;1 [13] [16] 
     brne    se0Delay        		;1 [14] [17] 

--- a/firmware/usbdrv/usbdrvasm20.inc
+++ b/firmware/usbdrv/usbdrvasm20.inc
@@ -153,7 +153,7 @@ bit7:
     sec                         ;[4]
     ror     shift               ;[5] shift "1" into the data
     st      y+, shift           ;[6] store the data into the buffer
-    ldi     shift, 0x40         ;[7] reset data for receiving the next byte
+    ldi     shift, 0x40         ;[8] reset data for receiving the next byte
     subi    leap, 0x55          ;[9] trick to introduce a leap cycle every 3 bytes
     brcc    nextInst            ;[10 or 11] it will fail after 85 bytes. However low speed can only receive 11
     dec     bitcnt              ;[11 or 12]


### PR DESCRIPTION
Hi,

  a non intrusive update from upstream just to be consistent with the latest v-usb code.

Changes :

- ( usbdrvasm15.inc ) * Fixed length of SE0 on 15 MHz clock.  Terminating SE0 was 3 CPU cycles longer than comments indicate.
- ( usbdrvasm20.inc ) * Fixed comments indicating CPU cycles taken.  ST instruction uses two cycles while LDI takes one.
- ( usbconfig.h ) Added missing configurations options.



