### PR TITLE
Fix the OS Extended Compat ID descriptor.

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -182,8 +182,6 @@ usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
 
 uchar usbFunctionSetup(uchar data[8]) {
 
-    const usbRequest_t* request = (const usbRequest_t*)data;
-
     uchar len = 0;
 
     if (data[1] == USBASP_FUNC_CONNECT) {
@@ -325,21 +323,22 @@ uchar usbFunctionSetup(uchar data[8]) {
         prog_state = PROG_STATE_TPI_WRITE;
         len = 0xff; /* multiple out */
     
-	/* Handle the OS feature request associated with the MS Vendor Code
-		we replied earlier in the OS String Descriptor request. See usbFunctionDescriptor. */
-	} else if (request->bRequest == MS_VENDOR_CODE) {		
-		if (request->wIndex.word == 0x0004)
-		{
-			/* Send the Extended Compat ID OS feature descriptor, 
-			  requesting to load the default winusb driver for us */
-			usbMsgPtr = (usbMsgPtr_t)&OS_EXTENDED_COMPAT_ID;
-			return sizeof(OS_EXTENDED_COMPAT_ID);
-		}
+    /* Handle the OS feature request associated with the MS Vendor Code
+     we replied earlier in the OS String Descriptor request. See usbFunctionDescriptor. */
+    } else if (data[1] == MS_VENDOR_CODE) {
+      if (data[4] == 4)
+      {
+           /* Send the Extended Compat ID OS feature descriptor, 
+              requesting to load the default winusb driver for us */
+        usbMsgPtr = (usbMsgPtr_t)&OS_EXTENDED_COMPAT_ID;
+        return sizeof(OS_EXTENDED_COMPAT_ID);
+      }
+      
+      return 0;
+	  
+    }
 
-		return 0;
-	}
-
-	 usbMsgPtr = replyBuffer;
+    usbMsgPtr = replyBuffer;
 
     return len;
 }

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -137,11 +137,11 @@ PROGMEM const char usbDescriptorDevice[18] = {    /* USB device descriptor */
 
 /* OS Extended Compat ID feature descriptor */
 
-PROGMEM const char OS_EXTENDED_COMPAT_ID[37] = {
+const char OS_EXTENDED_COMPAT_ID[40] = {
 	/* Header */
-	0x25,													/* OS Extended Compat ID feature descriptor length */
-	0x01, 0x00,												/* OS Extended Compat ID version */
-	0x00, 0x04,												/* Index */
+	0x28, 0x00, 0x00, 0x00,									/* OS Extended Compat ID feature descriptor length */
+	0x00, 0x01,												/* OS Extended Compat ID version */
+	0x04, 0x00,												/* Index */
 	0x01,													/* Configurations count */
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,				/* Reserved */
 	/* Configuration */


### PR DESCRIPTION
Hi,

  I have an error in the descriptor which I just fixed it. 
  
  Also, I could not manage to make it to work with PROGMEM so I left it in RAM. Maybe I'm just too tired and I miss something obvious. Is it possible to take a look ?

  This is ~~the~~ a valid first time enumeration captured ~~conversation~~ with pulseview just FYI .  In bold is the OS String Descriptor and OS Feature Descriptor requests and answers.

371403-374242 USB request: USB SETUP: SETUP out: [ 00 05 04 00 00 00 00 00 ][ ] : ACK
503968-518781 USB request: USB SETUP: SETUP in: [ 80 06 00 01 00 00 12 00 ][ 12 01 00 02 FF 00 00 08 C0 16 DC 05 07 01 01 02 03 01 ] : ACK
524701-545171 USB request: USB SETUP: SETUP in: [ 80 06 00 02 00 00 FF 00 ][ 09 02 12 00 01 01 00 A0 19 09 04 00 00 00 00 00 00 00 ] : ACK
**566438-582109 USB request: USB SETUP: SETUP in: [ 80 06 EE 03 00 00 12 00 ][ 12 03 4D 00 53 00 46 00 54 00 31 00 30 00 30 00 5D 00 ] : ACK**
600737-605976 USB request: USB SETUP: SETUP in: [ 80 06 03 03 09 04 FF 00 ][ ] : ACK
**608169-618496 USB request: USB SETUP: SETUP in: [ C0 5D 00 00 04 00 10 00 ][ 28 00 00 00 00 01 04 00 01 00 00 00 00 00 00 00 ] : ACK
621671-654503 USB request: USB SETUP: SETUP in: [ C0 5D 00 00 04 00 28 00 ][ 28 00 00 00 00 01 04 00 01 00 00 00 00 00 00 00 00 01 57 49 4E 55 53 42 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ] : ACK**
659345-666240 USB request: USB SETUP: SETUP in: [ 80 06 00 03 00 00 FF 00 ][ 04 03 09 04 ] : ACK
672093-684106 USB request: USB SETUP: SETUP in: [ 80 06 02 03 09 04 FF 00 ][ 0E 03 55 00 53 00 42 00 61 00 73 00 70 00 ] : ACK
718877-737199 USB request: USB SETUP: SETUP in: [ 80 06 00 01 00 00 12 00 ][ 12 01 00 02 FF 00 00 08 C0 16 DC 05 07 01 01 02 03 01 ] : ACK
739165-750059 USB request: USB SETUP: SETUP in: [ 80 06 00 02 00 00 09 00 ][ 09 02 12 00 01 01 00 A0 19 ] : ACK
750981-765214 USB request: USB SETUP: SETUP in: [ 80 06 00 02 00 00 12 00 ][ 09 02 12 00 01 01 00 A0 19 09 04 00 00 00 00 00 00 00 ] : ACK
766474-771316 USB request: USB SETUP: SETUP in: [ 80 00 00 00 00 00 02 00 ][ 00 00 ] : ACK
775617-777904 USB request: USB SETUP: SETUP out: [ 00 09 01 00 00 00 00 00 ][ ] : ACK

regards,
